### PR TITLE
ci: renamed a job on wc-upload

### DIFF
--- a/.github/workflows/wc-upload-coverage.yml
+++ b/.github/workflows/wc-upload-coverage.yml
@@ -2,7 +2,7 @@ name: wc-upload-coverage
 on:
   workflow_call:
 jobs:
-  upload-coverage:
+  push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# 🚀 Change Submission Form

## Overview
- [ ] **Apps/Packages**: Changes within `apps` or `packages`
- [x] **CI**: Updates to CI/CD integration or configuration
- [ ] **Test**: Additions or modifications to tests
- [x] **Refactoring**: Code structure or efficiency improvements without adding new features
- [ ] **Enhancement / Improvement**: Feature enhancements or improvements
- [ ] **Bugs Fixing**: Bug(s) fixing either on apps or packages
- [ ] **Others**

## Description
- Renamed `upload-coverage` to `push` on `wc-coverage`
## Changes
- **Summary**: Brief summary of the purpose and impact of these changes.
- **Related Issue**: If applicable, link to any related issues or tickets.

## Additional Notes
Include any additional notes or context here.